### PR TITLE
Add Steering Committee meeting agenda process and tools

### DIFF
--- a/.github/workflows/create-meeting-agenda.yml
+++ b/.github/workflows/create-meeting-agenda.yml
@@ -1,0 +1,59 @@
+name: Create Meeting Agenda
+
+# Creates the next ODP Steering Committee meeting agenda. This workflow only
+# runs a script and opens a pull request when a new agenda is produced.
+
+on:
+  schedule:
+    # Nightly at 07:00 UTC.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  create-agenda:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'OpenDevicePartnership'
+    steps:
+      - name: Check Out Repository
+        uses: actions/checkout@v6
+
+      - name: Set Up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install Dependencies
+        run: pip install -r steering-committee-meetings/scripts/requirements.txt
+
+      - name: Generate Agenda If Due
+        id: agenda
+        # A manual dispatch skips the post-meeting lead-time wait.
+        run: >-
+          python steering-committee-meetings/scripts/generate_agenda.py
+          --if-due
+          ${{ github.event_name == 'workflow_dispatch' && '--ignore-lead-time' || '' }}
+
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.ODP_CI_APPLICATION_ID }}
+          private-key: ${{ secrets.ODP_CI_APPLICATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Open Pull Request for New Agenda
+        if: steps.agenda.outputs.created == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: agenda/${{ steps.agenda.outputs.meeting_date }}
+          title: "Add agenda for ODP Steering Committee meeting on ${{ steps.agenda.outputs.meeting_date }}"
+          body: |
+            Automated agenda for the ODP Steering Committee meeting on
+            ${{ steps.agenda.outputs.meeting_date }}.
+          commit-message: "Add agenda for meeting on ${{ steps.agenda.outputs.meeting_date }}"
+          assignees: ${{ steps.agenda.outputs.chair_github }}
+          team-reviewers: odp-steering-committee
+          token: ${{ steps.app-token.outputs.token }}

--- a/STEERING-COMMITTEE-MEETING.md
+++ b/STEERING-COMMITTEE-MEETING.md
@@ -1,0 +1,135 @@
+# Open Device Partnership Steering Committee Meeting Process
+
+A monthly Open Device Partnership (ODP) Steering Committee meeting is held to discuss and make decisions on important
+matters related to the project. The meeting is scheduled on a monthly recurring basis and open to all members of the
+Open Device Partnership community. The agenda is built in advance using pull requests to a markdown file in the
+[`OpenDevicePartnership/governance`](https://github.com/OpenDevicePartnership/governance) repository.
+
+Anyone is welcome to create pull requests to add items to the agenda. The committee is chaired by a designated Open
+Device Partnership Steering Committee member. While the primary participants in the meeting are the members of the Open
+Device Partnership Steering Committee, the meeting chair is responsible for ensuring that the meeting is inclusive and
+that all voices are heard.
+
+This meeting only discusses Open Device Partnership organizational and process matters. Technical discussions and
+decisions are made in separate meetings that are focused on technical topics led by the appropriate project lead.
+
+## Meeting Agenda Process
+
+Note: The `governance` repository requires two approvals to merge a pull request. In cases below where only one approval
+is required, the pull request may be merged by an admin by overriding the approval requirement in order to meet the
+expected timelines for merging the pull request if necessary. If that is not required at the time, the pull request can
+simply be merged with two approvals as usual.
+
+1. An automated process creates a pull request to the [`OpenDevicePartnership/governance`](https://github.com/OpenDevicePartnership/governance)
+   repository to add a new agenda markdown file in the `steering-committee-meetings` directory for the next meeting.
+   The pull request is assigned to the meeting chair. The pull request includes all ODP Steering Committee members as
+   reviewers.
+   - This pull request must not add any content other than the new agenda markdown file with template fields customized
+     for the next meeting.
+2. Any ODP Steering Committee member can merge the file once at least one other ODP Steering Committee member has
+   approved the pull request. The meeting chair is responsible for ensuring that the pull request is merged in a timely
+   manner after it has received the necessary approvals, ideally within three business days of the pull request being
+   created.
+3. Once the upcoming meeting agenda file is merged, pull requests may be created to add items to the agenda.
+    - The pull request should include a description of the agenda item(s) and any relevant links to documentation or
+      discussions to support the item(s) in the markdown file.
+    - The pull request should be assigned to the meeting chair and include all ODP Steering Committee members as
+      reviewers.
+    - At least two ODP Steering Committee members must approve the pull request for it to be merged. The meeting chair
+      is responsible for ensuring that pull requests to add items to the agenda are merged in a timely manner after they
+      have received the necessary approvals. The meeting chair should prioritize reviewing and approving pull requests,
+      but their approval is not mandatory.
+    - Reviewers should ensure that:
+      - The agenda item is relevant to the Open Device Partnership organization and appropriate for discussion in the
+        Steering Committee meeting.
+        - In particular, that the item is not primarily technical in nature and would be more appropriate for
+          discussion in a technical meeting led by the relevant project lead.
+      - The description of the agenda item is clear and includes sufficient context or links to support the proposed
+        discussion.
+      - The agenda item requires a decision to be made by the Steering Committee or is otherwise important to discuss
+        in the Steering Committee meeting and cannot be resolved through asynchronous discussion on GitHub.
+        - Note: "Asynchronous discussion" refers to discussions that can be conducted through GitHub issues, pull
+          requests, or other communication channels without requiring a real-time meeting.
+4. At least two days prior to the scheduled meeting, the meeting chair should ensure that the agenda is finalized and
+   published by merging any remaining open pull requests for agenda items for the upcoming meeting. The meeting chair
+   should also ensure that any pull requests for agenda items that have not received the necessary approvals are closed
+   and that the contributors to those pull requests are informed of the reason for closing the pull request.
+   - The meeting chair is responsible for creating a pull request that updates the status in the agenda file to "Final".
+     - This pull request only requires a single approval from an ODP Steering Committee member to be merged. The
+       meeting chair should merge the pull request to finalize the agenda in a timely manner, ideally within one
+       business day after all pull requests for agenda items have been merged and the agenda is finalized.
+     - New items may not be added after the agenda is finalized, but existing items may be modified or removed as
+       needed with the necessary approvals.
+
+### Meeting Agenda Statuses
+
+- **Draft:** The agenda is being built and is not yet finalized. New items may be added to the agenda through pull
+  requests that receive the necessary approvals.
+- **Final:** The agenda is finalized and published. No new items may be added to the agenda, but existing items may be
+  modified or removed as needed with the necessary approvals.
+- **Canceled:** The meeting has been canceled. No items may be added, modified, or removed from the agenda. The meeting
+  chair should follow the process outlined in the [Meeting Cancellation](#meeting-cancellation) section below when
+  canceling a meeting.
+
+## Meeting Cancellation
+
+The meeting chair may cancel an upcoming meeting at any time.
+
+The meeting chair should cancel the meeting when:
+
+- There are no agenda items, or there are not enough approved agenda items to support a meaningful discussion.
+
+The meeting chair should also consider canceling the meeting when:
+
+- There are not enough ODP Steering Committee members available to attend.
+- Key stakeholders for a given agenda item are not available to attend.
+
+When a meeting is canceled, the meeting chair is responsible for the following:
+
+- Inform the ODP Steering Committee and the broader Open Device Partnership community of the cancellation and the reason
+  for it in a timely manner.
+- Update the agenda file for the canceled meeting to mark its status as "Canceled".
+- Manually run the GitHub workflow to create the agenda file for the next meeting. That pull request follows the normal
+  process for adding a new agenda file.
+- Determine whether any agenda items planned for the canceled meeting should be carried over to the next meeting or can
+  be resolved through asynchronous discussion on GitHub. If an item must be included in a future meeting, the chair
+  creates a pull request to the next meeting's agenda file that adds the relevant items, following the normal process for
+  adding agenda items, including obtaining the necessary approvals from ODP Steering Committee members.
+
+## Meeting Process
+
+During the meeting, the chair should follow the published agenda and facilitate discussion on each item. The primary
+participants in the discussion should be the ODP Steering Committee members, but the chair should ensure that discussion
+is inclusive. The submitter of an agenda item is not required to attend the meeting for the item to be discussed, but
+they are welcome to attend and participate in the discussion.
+
+For agenda items that require a decision to be made by the Steering Committee, the chair should facilitate discussion
+until there is a clear consensus among the Steering Committee members on the decision. The chair may use a formal voting
+process if needed to reach a decision, but the goal should be to reach consensus through discussion whenever possible.
+The chair should ensure that all voices are heard during the discussion and that the decision is made in the best
+interest of the Open Device Partnership project and community.
+
+- Major new topic areas are not allowed to be added to the agenda in the meeting. They must be added to a future meeting
+  agenda in a pull request.
+- Non-Steering Committee members are welcome to attend the meeting and participate in the discussion, but they do not
+  have voting rights in any decisions made by the Steering Committee. The chair should ensure that non-Steering Committee
+  members have an opportunity to share their perspectives during the discussion, but the final decision on any agenda
+  item is made by the Steering Committee members.
+
+## Meeting Follow-Up
+
+The meeting chair is responsible for ensuring that any decisions made during the meeting are documented in the meeting
+minutes and that any action items resulting from the meeting are assigned to the appropriate individuals or teams for
+follow-up. The meeting chair should also ensure that the meeting minutes are published and shared with the ODP Steering
+Committee and the broader Open Device Partnership community in a timely manner after the meeting.
+
+Meeting minutes may be recorded manually or through an automated process, but they should include a summary of the
+discussion for each agenda item, the decisions made, and any action items assigned. In addition, all Open Device
+Partnership Steering Committee meetings are recorded and the videos are published to the ODP YouTube channel.
+
+The meeting chair should ensure that the meeting minutes are accurate and complete, and that they reflect the outcomes
+of the meeting in a clear and concise manner.
+
+Meeting minutes are added to the "Meeting Minutes" section of the agenda file for the meeting in a pull request created
+by the meeting chair. This section also includes a link to the YouTube video recording of the meeting. This pull request
+must be approved by at least one ODP Steering Committee member before it can be merged.

--- a/steering-committee-meetings/README.md
+++ b/steering-committee-meetings/README.md
@@ -1,0 +1,41 @@
+# Steering Committee Meetings
+
+This directory holds the ODP Steering Committee meeting agendas and the tooling that generates them. The meeting
+process itself (how agendas are proposed, approved, finalized, and recorded) is defined in [STEERING-COMMITTEE-MEETING.md](../STEERING-COMMITTEE-MEETING.md).
+
+Note: This process is automated on GitHub. In the normal case, no one is expected to run the agenda generator script
+or create agenda files manually.
+
+## Contents
+
+- `agenda-template.md` - The reference agenda template used by automation to create new agendas and serves as a general
+  reference for the agenda document structure.
+- `YYYY-MM-DD.md` - A generated agenda for a specific meeting date.
+  - These files can be modified with pull requests while in "Draft" status.
+- `scripts/` - The agenda generator script and its configuration.
+
+## Generating an agenda
+
+The generator fills the template's meeting details from `scripts/config.toml` and determines the meeting date from the
+recurrence rule in that file.
+
+Steps to run the agenda generator script manually:
+
+```sh
+# Note: Requires Python 3.11+.
+# Install dependencies once.
+py -3 -m pip install -r scripts/requirements.txt
+
+# Create the agenda for the next scheduled meeting.
+py -3 scripts/generate_agenda.py
+
+# Other options: Such as a specific month or an explicit date.
+py -3 scripts/generate_agenda.py --month 2026-08
+py -3 scripts/generate_agenda.py --date 2026-08-04
+```
+
+## Automation
+
+The `Create Meeting Agenda` workflow ([.github/workflows/create-meeting-agenda.yml](../.github/workflows/create-meeting-agenda.yml))
+runs nightly. It calls `generate_agenda.py --if-due`, which creates the next agenda only once it has been at least two
+days since the previous meeting, then opens a pull request. It can also be triggered manually on GitHub if needed.

--- a/steering-committee-meetings/agenda-template.md
+++ b/steering-committee-meetings/agenda-template.md
@@ -1,0 +1,76 @@
+<!-- Open Device Partnership (ODP) Steering Committee Meeting Agenda
+     File name: YYYY-MM-DD.md (the scheduled meeting date). -->
+
+# ODP Steering Committee Meeting: YYYY-MM-DD
+
+<!--
+The Date, Time, Meeting Chair, and Location / Join Link fields below are filled
+in automatically by scripts/generate_agenda.py from scripts/config.toml. When
+creating an agenda with that script, leave their placeholders as-is. Edit them
+by hand only if you are writing the agenda manually.
+-->
+
+- **Status:** Draft <!-- Draft | Final | Canceled -->
+- **Date:** YYYY-MM-DD
+- **Time:** HH:MM–HH:MM [timezone]
+- **Meeting Chair:** Name (GitHub: @alias)
+- **Location / Join Link:** [link]
+
+> The agenda is built in advance through pull requests to this file. Anyone is welcome to propose an agenda item by
+> opening a pull request that adds it to the [Agenda Items](#agenda-items) section. Items require approval from at least
+> two ODP Steering Committee members before they are merged. New items may not be added after the status is set to
+> "Final".
+
+## Agenda Items
+
+<!--
+Add one entry per agenda item using the block below. Remove this comment and the examples before finalizing.
+Each item must be relevant to ODP organizational or process matters. Primarily technical topics scoped to a specific
+project should be discussed in a technical meeting led by the relevant project lead instead of in the Steering Committee
+meeting.
+-->
+
+### Item 1: [Agenda item title]
+
+- **Submitter:** Name (GitHub: @alias)
+- **Decision required:** Yes / No
+- **Summary:** A clear description of the item and the discussion or decision being requested.
+- **Supporting links:**
+  - [Description / context](link)
+
+### Item 2: [Agenda item title]
+
+- **Submitter:** Name (GitHub: @alias)
+- **Decision required:** Yes / No
+- **Summary:** A clear description of the item and the discussion or decision being requested.
+- **Supporting links:**
+  - [Description / context](link)
+
+## Meeting Minutes
+
+<!--
+Completed by the meeting chair after the meeting in a separate pull request.
+Requires approval from at least one ODP Steering Committee member before it can be merged.
+-->
+
+- **Recording:** [YouTube video](link)
+
+### Discussion Summary
+
+For each agenda item, summarize the discussion and the decision made.
+
+#### Minutes for Item 1
+
+- **Discussion:** Summary of the discussion.
+- **Decision:** The decision reached, or note that no decision was made.
+
+#### Minutes for Item 2
+
+- **Discussion:** Summary of the discussion.
+- **Decision:** The decision reached, or note that no decision was made.
+
+### Action Items
+
+| Action item | Owner | Due date |
+| ----------- | ----- | -------- |
+| Description | Name (GitHub: @alias) | YYYY-MM-DD |

--- a/steering-committee-meetings/scripts/config.toml
+++ b/steering-committee-meetings/scripts/config.toml
@@ -1,0 +1,29 @@
+# Open Device Partnership (ODP) Steering Committee meeting configuration.
+
+[meeting]
+# Meeting start and end times in 24-hour HH:MM format.
+# They are rendered in the agenda with am/pm (for example "9:00 AM").
+time_start = "09:00"
+time_end = "10:00"
+
+# IANA timezone name (see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+# The agenda spells this out for the meeting date, including daylight saving
+# (for example "America/Los_Angeles" renders as "Pacific Daylight Time" in
+# summer and "Pacific Standard Time" in winter).
+timezone = "America/Los_Angeles"
+
+# The default meeting chair. Update this when the chair role rotates.
+chair_name = "Karan Dhillon"
+chair_github = "dhillonk"
+
+# Where the meeting takes place, or the link participants use to join.
+location = "https://teams.microsoft.com/meet/253907517636673?p=2yg2pES56LxzyL1HDg"
+
+[recurrence]
+# The meeting recurs on the Nth weekday of every month. The script computes the
+# next occurrence on or after today (override with --month or --date).
+#
+#   ordinal: first | second | third | fourth | fifth | last
+#   weekday: Monday | Tuesday | Wednesday | Thursday | Friday | Saturday | Sunday
+ordinal = "first"
+weekday = "Thursday"

--- a/steering-committee-meetings/scripts/generate_agenda.py
+++ b/steering-committee-meetings/scripts/generate_agenda.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Generate an ODP Steering Committee meeting agenda from the template.
+
+The script fills in the relatively stable meeting details (time, chair, and
+location) from a TOML configuration file and computes the meeting date from a
+recurring "Nth weekday of the month" pattern, also described in the config.
+
+It renders ``agenda-template.md`` into a dated ``YYYY-MM-DD.md`` file, removing
+some content so the generated agenda only contains the content contributors
+edit.
+
+Usage examples::
+
+    py -3 generate_agenda.py                              # next meeting from today
+    py -3 generate_agenda.py --month 2026-08              # meeting in a specific month
+    py -3 generate_agenda.py --date 2026-08-04
+    py -3 generate_agenda.py --if-due                     # create only when due
+    py -3 generate_agenda.py --if-due --ignore-lead-time  # manual dispatch
+"""
+
+from __future__ import annotations
+
+import argparse
+import calendar
+import os
+import re
+import tomllib
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+try:
+    from babel.dates import get_timezone_name
+except ModuleNotFoundError as exc:  # pragma: no cover - dependency guard
+    raise SystemExit(
+        "This script requires the 'babel' package. Install dependencies "
+        "with: py -3 -m pip install -r "
+        "steering-committee-meetings/scripts/requirements.txt"
+    ) from exc
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+MEETINGS_DIR = SCRIPT_DIR.parent
+DEFAULT_CONFIG = SCRIPT_DIR / "config.toml"
+DEFAULT_TEMPLATE = MEETINGS_DIR / "agenda-template.md"
+
+WEEKDAYS = {
+    name.lower(): index for index, name in enumerate(calendar.day_name)
+}
+ORDINALS = {"first": 0, "second": 1, "third": 2, "fourth": 3, "fifth": 4}
+COMMENT_PATTERN = re.compile(r"<!--.*?-->", re.DOTALL)
+
+# How many days after a meeting the next agenda should be created. The nightly
+# --if-due run waits this long so the just-completed meeting's minutes can be
+# added before the next agenda appears.
+AGENDA_LEAD_DAYS = 2
+
+# Status value (compared case-insensitively) that marks a meeting's agenda as
+# canceled. A canceled meeting's agenda file remains in the repository, so
+# --if-due must look past it when deciding whether the next agenda is missing.
+CANCELED_STATUS = "canceled"
+
+
+def load_config(path: Path) -> dict:
+    """Load and minimally validate the meeting configuration."""
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Configuration file not found: {path}\n"
+            "Create a 'config.toml' with [meeting] and [recurrence] sections "
+            "(see steering-committee-meetings/README.md)."
+        )
+    with path.open("rb") as handle:
+        config = tomllib.load(handle)
+
+    for section in ("meeting", "recurrence"):
+        if section not in config:
+            raise ValueError(f"Missing required [{section}] section in {path}")
+    return config
+
+
+def nth_weekday_of_month(
+    year: int, month: int, weekday: int, ordinal: str
+) -> date:
+    """Return the date of the Nth (or last) weekday in the given month."""
+    matching = [
+        week[weekday]
+        for week in calendar.monthcalendar(year, month)
+        if week[weekday] != 0
+    ]
+    if ordinal == "last":
+        return date(year, month, matching[-1])
+
+    index = ORDINALS[ordinal]
+    if index >= len(matching):
+        raise ValueError(
+            f"There is no '{ordinal}' {calendar.day_name[weekday]} in "
+            f"{calendar.month_name[month]} {year}."
+        )
+    return date(year, month, matching[index])
+
+
+def meeting_date_for_month(recurrence: dict, year: int, month: int) -> date:
+    """Compute the meeting date within a month from the recurrence rule."""
+    weekday_name = str(recurrence["weekday"]).lower()
+    ordinal = str(recurrence["ordinal"]).lower()
+
+    if weekday_name not in WEEKDAYS:
+        raise ValueError(
+            f"Invalid recurrence weekday: {recurrence['weekday']!r}"
+        )
+    if ordinal != "last" and ordinal not in ORDINALS:
+        raise ValueError(
+            f"Invalid recurrence ordinal: {recurrence['ordinal']!r}"
+        )
+
+    return nth_weekday_of_month(year, month, WEEKDAYS[weekday_name], ordinal)
+
+
+def next_meeting_date(recurrence: dict, today: date) -> date:
+    """Find the next meeting date on or after ``today``."""
+    candidate = meeting_date_for_month(recurrence, today.year, today.month)
+    if candidate >= today:
+        return candidate
+
+    # This month's meeting has passed, so advance to the next month.
+    if today.month == 12:
+        year, month = today.year + 1, 1
+    else:
+        year, month = today.year, today.month + 1
+    return meeting_date_for_month(recurrence, year, month)
+
+
+def meeting_after(recurrence: dict, meeting_day: date) -> date:
+    """Return the first meeting date strictly after ``meeting_day``."""
+    return next_meeting_date(recurrence, meeting_day + timedelta(days=1))
+
+
+def last_meeting_date(recurrence: dict, today: date) -> date:
+    """Find the most recent meeting date on or before ``today``."""
+    candidate = meeting_date_for_month(recurrence, today.year, today.month)
+    if candidate <= today:
+        return candidate
+
+    # This month's meeting has not happened yet, so fall back to last month.
+    if today.month == 1:
+        year, month = today.year - 1, 12
+    else:
+        year, month = today.year, today.month - 1
+    return meeting_date_for_month(recurrence, year, month)
+
+
+def format_time_label(value: str) -> str:
+    """Convert a 24-hour ``HH:MM`` string to a 12-hour label with am/pm."""
+    parsed = datetime.strptime(value, "%H:%M")
+    label = parsed.strftime("%I:%M %p")  # e.g. "09:00 AM"
+    return label[1:] if label.startswith("0") else label
+
+
+def format_meeting_time(meeting: dict, meeting_day: date) -> str:
+    """Build the time field with am/pm times and a spelled-out timezone."""
+    tz_key = str(meeting["timezone"])
+    try:
+        tzinfo = ZoneInfo(tz_key)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(
+            f"Unknown timezone {tz_key!r}. Use an IANA name such as "
+            "'America/Los_Angeles'. On Windows, ensure the 'tzdata' "
+            "package is installed."
+        ) from exc
+
+    start_time = datetime.strptime(meeting["time_start"], "%H:%M").time()
+    start_dt = datetime.combine(meeting_day, start_time, tzinfo=tzinfo)
+    # Resolving the name against the concrete date yields the correct
+    # daylight/standard variant (for example "Pacific Daylight Time").
+    tz_name = get_timezone_name(start_dt, width="long", locale="en_US")
+
+    start_label = format_time_label(meeting["time_start"])
+    end_label = format_time_label(meeting["time_end"])
+    return f"{start_label} \u2013 {end_label} {tz_name}"
+
+
+def format_location(value: str) -> str:
+    """Wrap a join URL in an autolink so markdown linters do not flag it."""
+    value = value.strip()
+    if value.startswith(("http://", "https://")):
+        return f"<{value}>"
+    return value
+
+
+def build_context(config: dict, meeting_day: date) -> dict[str, str]:
+    """Assemble the metadata values that replace the template placeholders."""
+    meeting = config["meeting"]
+    chair = f"{meeting['chair_name']} (GitHub: @{meeting['chair_github']})"
+    return {
+        "date": meeting_day.isoformat(),
+        "time": format_meeting_time(meeting, meeting_day),
+        "chair": chair,
+        "location": format_location(str(meeting["location"])),
+    }
+
+
+def agenda_status(path: Path) -> str | None:
+    """Return the status value recorded in an existing agenda file.
+
+    Looks for the ``- **Status:**`` line, strips any trailing HTML comment,
+    and returns the remaining text. Returns ``None`` if the file cannot be
+    read or has no status line.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- **Status:**"):
+            value = stripped[len("- **Status:**"):]
+            value = COMMENT_PATTERN.sub("", value)
+            return value.strip()
+    return None
+
+
+def render_agenda(template_text: str, context: dict[str, str]) -> str:
+    """Strip reference comments and fill in the meeting metadata."""
+    text = COMMENT_PATTERN.sub("", template_text)
+
+    replacements = {
+        "# ODP Steering Committee Meeting":
+            f"# ODP Steering Committee Meeting: {context['date']}",
+        "- **Date:**": f"- **Date:** {context['date']}",
+        "- **Time:**": f"- **Time:** {context['time']}",
+        "- **Meeting Chair:**": f"- **Meeting Chair:** {context['chair']}",
+        "- **Location / Join Link:**":
+            f"- **Location / Join Link:** {context['location']}",
+    }
+
+    rendered_lines = []
+    for line in text.splitlines():
+        stripped = line.rstrip()
+        for prefix, replacement in replacements.items():
+            if stripped.startswith(prefix):
+                stripped = replacement
+                break
+        rendered_lines.append(stripped)
+
+    # Collapse the blank lines left behind by removed comments.
+    body = re.sub(r"\n{3,}", "\n\n", "\n".join(rendered_lines))
+    return body.strip() + "\n"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG,
+        help="Path to the TOML config (default: config.toml).",
+    )
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=DEFAULT_TEMPLATE,
+        help="Path to the agenda template file.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=MEETINGS_DIR,
+        help="Directory for the generated agenda file.",
+    )
+
+    date_group = parser.add_mutually_exclusive_group()
+    date_group.add_argument(
+        "--month",
+        help="Target month as YYYY-MM. Applies the recurrence rule.",
+    )
+    date_group.add_argument(
+        "--date",
+        help="Explicit meeting date as YYYY-MM-DD. Overrides recurrence.",
+    )
+
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite the output file if it already exists.",
+    )
+    parser.add_argument(
+        "--if-due",
+        action="store_true",
+        help=(
+            "Create the next agenda only when it has been at least "
+            f"{AGENDA_LEAD_DAYS} days since the last meeting and the file "
+            "does not already exist. A canceled meeting's agenda is skipped "
+            "so the following meeting's agenda is created. Intended for "
+            "scheduled automation."
+        ),
+    )
+    parser.add_argument(
+        "--ignore-lead-time",
+        action="store_true",
+        help=(
+            "With --if-due, skip the "
+            f"{AGENDA_LEAD_DAYS}-day post-meeting wait. Intended for a "
+            "manual workflow dispatch (for example, creating the next "
+            "agenda right after a meeting is canceled)."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def emit_github_output(**values: str) -> None:
+    """Write ``key=value`` pairs to the GitHub Actions output file, if set."""
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if not output_file:
+        return
+    with open(output_file, "a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            handle.write(f"{key}={value}\n")
+
+
+def write_agenda(
+    args: argparse.Namespace, config: dict, meeting_day: date
+) -> Path:
+    """Render and write the agenda file for ``meeting_day``."""
+    context = build_context(config, meeting_day)
+    template_text = args.template.read_text(encoding="utf-8")
+    agenda_text = render_agenda(template_text, context)
+    output_path = args.output_dir / f"{meeting_day.isoformat()}.md"
+    output_path.write_text(agenda_text, encoding="utf-8")
+    return output_path
+
+
+def resolve_meeting_date(args: argparse.Namespace, recurrence: dict) -> date:
+    if args.date:
+        return date.fromisoformat(args.date)
+    if args.month:
+        year, month = (int(part) for part in args.month.split("-", 1))
+        return meeting_date_for_month(recurrence, year, month)
+    return next_meeting_date(recurrence, date.today())
+
+
+def run_if_due(args: argparse.Namespace, config: dict) -> int:
+    """Create the next agenda only when scheduling is due and it is missing."""
+    recurrence = config["recurrence"]
+    today = date.today()
+    last_meeting = last_meeting_date(recurrence, today)
+    days_since = (today - last_meeting).days
+
+    # The lead-time wait keeps the nightly scheduled run from creating the next
+    # agenda before the just-completed meeting's minutes can be added. A manual
+    # dispatch (--ignore-lead-time) is an explicit request, so it skips the
+    # wait. This might be used to create the next agenda immediately after
+    # canceling a meeting.
+    if not args.ignore_lead_time and days_since < AGENDA_LEAD_DAYS:
+        print(
+            f"Not due: the last meeting ({last_meeting.isoformat()}) was "
+            f"{days_since} day(s) ago. Waiting for {AGENDA_LEAD_DAYS}."
+        )
+        emit_github_output(created="false")
+        return 0
+
+    meeting_day = next_meeting_date(recurrence, today)
+    output_path = args.output_dir / f"{meeting_day.isoformat()}.md"
+
+    # Skip past meetings that already have an agenda. A canceled meeting's
+    # agenda file stays in the repository, so when the next scheduled meeting
+    # is canceled this advances to the following meeting.
+    while output_path.exists():
+        status = agenda_status(output_path)
+        if status is not None and status.lower() == CANCELED_STATUS:
+            print(f"Skipping canceled meeting agenda: {output_path}")
+            meeting_day = meeting_after(recurrence, meeting_day)
+            output_path = args.output_dir / f"{meeting_day.isoformat()}.md"
+            continue
+        print(f"Agenda already exists: {output_path}")
+        emit_github_output(
+            created="false", meeting_date=meeting_day.isoformat()
+        )
+        return 0
+
+    output_path = write_agenda(args, config, meeting_day)
+    print(f"Created agenda: {output_path}")
+    emit_github_output(
+        created="true",
+        meeting_date=meeting_day.isoformat(),
+        agenda_file=str(output_path),
+        chair_github=str(config["meeting"]["chair_github"]),
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    config = load_config(args.config)
+
+    if args.if_due:
+        return run_if_due(args, config)
+
+    meeting_day = resolve_meeting_date(args, config["recurrence"])
+    output_path = args.output_dir / f"{meeting_day.isoformat()}.md"
+    if output_path.exists() and not args.force:
+        print(
+            f"Refusing to overwrite existing file: {output_path} "
+            "(use --force)."
+        )
+        return 1
+
+    output_path = write_agenda(args, config, meeting_day)
+    print(f"Created agenda: {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/steering-committee-meetings/scripts/requirements.txt
+++ b/steering-committee-meetings/scripts/requirements.txt
@@ -1,0 +1,9 @@
+# Dependencies for the agenda generation script.
+# Install from the repository root with:
+#   py -3 -m pip install -r steering-committee-meetings/scripts/requirements.txt
+
+# Locale-aware formatting of spelled-out timezone names.
+babel
+
+# IANA timezone database for zoneinfo. Required on Windows, no-op on Unix.
+tzdata


### PR DESCRIPTION
Introduces the ODP Steering Committee meeting process, associated documentation, and automation tools.

**Primary Process Document**

- `STEERING-COMMITTEE-MEETING.md`: Documents the agenda, cancellation, meeting, and follow-up process.

---

**Agenda Automation Content**

Summary: A GitHub workflow wraps a Python script to generate a blank agenda for an upcoming meeting. Nearly all logic is in the Python script since it is more maintainable that a workflow file. Basic info (like meeting chair, the Teams link, etc. is in config.toml). It only needs to be edited when that info changes. Once a month, a pull request will be created with a blank agenda file for the upcoming meeting. The date, time, and Teams link will be filled in. Once approved and checked in, new agenda items are added to the file manually by anyone with pull requests. Steering committee members approve pull requests, and the overall process follows that described in `STEERING-COMMITTEE-MEETING.md`.

- `steering-committee-meetings/agenda-template.md`: Agenda template.
- `steering-committee-meetings/scripts/generate_agenda.py`: Generates an agenda from the template and config files.
- `steering-committee-meetings/scripts/config.toml`: Meeting details used to create the upcoming agenda.
- `steering-committee-meetings/scripts/requirements.txt`: Python dependencies for the agenda generation script.
- `.github/workflows/create-meeting-agenda.yml`: Nightly workflow that generates the next agenda when due and opens a pull request.

---

**Miscellaneous Docs**

- `steering-committee-meetings/README.md`: Brief information on directory overview and usage.