### PR TITLE
[FCP] RFC 0036: Update ODP Private Repository Access Control

### DIFF
--- a/rfc/0036-private-repo-access-control.md
+++ b/rfc/0036-private-repo-access-control.md
@@ -1,27 +1,40 @@
-# RFC: Default Private Repository Access by Explicit Access List Only
+# RFC: Private Repository Access and Role
 
 This RFC proposes that repositories in Open Device Partnership (ODP) that are marked as **private** should be invisible
 and inaccessible to ODP organization members by default unless those members are explicitly granted access through an
 approved team or direct repository permission.
+
+It also defines the limited role of private repositories in ODP. A private repository is only a temporary staging state
+for content that is intended to become public. Confidential content, and repositories with no plan to become public, do
+not belong in the open-source ODP organization. Updated the Alternatives section to remove stale content.
 
 ## Change Log
 
 - 2026-06-08: Initial RFC draft created.
 - 2026-06-11: Addressed review feedback — explicit org admin visibility, required team-based access, 6-month audit
   evidence, private-to-public intent and transition checklist.
+- 2026-08-03: Clarified that private repositories are only a temporary staging mechanism for content intended to become
+  public, and that confidential content and repositories with no plan to become public do not belong in the ODP
+  organization. Simplified access controls accordingly.
 
 ## Motivation
 
-ODP has both public and private repositories. Private repositories are often used for early-stage, partner-sensitive, or
-pre-disclosure work that should not be broadly visible. Today, all ODP organization members can see all private
-repositories by default, which weakens confidentiality controls and makes "private" less predictable in practice.
+ODP exists to promote cooperative innovation in firmware development through contribution and transparency. The ODP
+GitHub organization is meant to be an open, collaborative community where every level of access, from reader to
+administrator, is available to participants regardless of their employer or affiliation. To realize that goal, ODP must
+ensure that content added to the organization is scoped appropriately.
 
-This RFC applies a least-privilege model to private repositories:
+Private repositories exist to stage content that is intended to become public while it is being prepared for release. A
+private repository is a temporary holding state, not a permanent destination. Content that will never be published, and
+content that carries a confidentiality obligation, does not belong in the ODP organization.
 
-- Being a member of ODP should **not** by itself imply visibility into private repositories.
-- Access to a private repository should be intentional, reviewable, and auditable.
-- Repository owners should be able to keep early-stage work, partner-sensitive material, and limited-distribution
-  discussions private without relying on informal expectations.
+This RFC therefore applies two main policies:
+
+1. A least-privilege access model, so membership in ODP does not by itself grant visibility into private repositories
+   and access is instead intentional and explicitly granted.
+2. A scope control, so private repositories are limited to temporarily staging content that is actively being prepared
+   for public release, and repositories with a confidentiality element or with no plan to become public are kept out of
+   the ODP organization.
 
 ## Technology Background
 
@@ -38,69 +51,48 @@ RFC changes that model so private repository access is granted only through expl
 
 The goals of this RFC are:
 
-1. Ensure private repositories are visible only to explicitly authorized users.
-2. Reduce accidental overexposure of pre-release, partner-sensitive, or incubation work.
-3. Improve auditability of who has access to sensitive repositories.
-4. Encourage repository owners to make an intentional visibility choice:
+1. Keep the ODP organization open and transparent, with equal access for all participants regardless of affiliation.
+2. Limit private repositories to temporarily staging content that is intended and being actively prepared to become
+   public.
+3. Keep confidential content, including material covered by a non-disclosure agreement, out of the ODP organization.
+4. Keep repositories that have no plan to become public out of the ODP organization.
+5. Ensure private repositories are visible only to explicitly authorized users while they remain private.
+6. Encourage repository owners to make an intentional visibility choice:
    - **Public** when broad collaboration is desired.
-   - **Private** when access should be tightly controlled.
+   - **Private** only as a temporary staging state for content being prepared for public release.
 
 ## Requirements
 
 The following requirements define the proposed policy:
 
-1. **No implied access from ODP membership alone**  
-   Membership in the ODP GitHub organization must not, by itself, grant visibility into or access to any private
-   repository. ODP GitHub organization owners (admins) retain full visibility and access to all repositories, including
-   private repositories, as this is inherent to the GitHub platform administration role.
+1. **No implied access from ODP membership alone**: Membership in the ODP GitHub organization must not, by itself, grant
+   visibility into or access to any private repository. ODP GitHub organization owners (admins) retain full visibility
+   and access to all repositories, including private repositories, as this is inherent to the GitHub platform
+   administration role.
 
-2. **Explicit authorization required**  
-   A user must be explicitly granted access to a private repository through one of the following:
-   - Add to a GitHub team that has been granted permissions to that repository (preferred).
-3. **Default deny for private repositories**  
-   Private repositories must default to a deny-by-default posture. No broad organization-wide read access should be
-   assumed or inherited for private repositories. At the GitHub organization level, base access must be configured so
-   private repository visibility is not granted through membership alone.
+2. **Team-based access required by default**: Team-based access is the required model for private repos for
+   maintainability and clear ownership. Users should be added to an appropriate team rather than granted individual
+   access.
 
-4. **Team-based access required by default**  
-   Team-based access is the required model for maintainability and auditability. Users should be added to an appropriate
-   team rather than granted individual access.
+3. **ODP platform and framework code must become public**: Any ODP platform or framework code developed within a private
+   repository must be published to a public ODP repository. A private repository must not become the permanent or sole
+   home for reusable ODP platform or framework work. While a repository remains private, it must still comply with all
+   other requirements in this RFC.
 
-5. **6-month access audit**  
-   Owners or designated maintainers of a private repository must review its access list at least every six months and
-   remove stale or unnecessary access.
-
-6. **Audit evidence and record-keeping**  
-   Each 6-month access review must produce a permanent, verifiable record confirming the audit was performed. Acceptable
-   evidence includes a dated issue or pull request in the repository, or a signed-off audit log. ODP should provide an
-   automated mechanism (for example, a scheduled GitHub Actions workflow) that reminds repository owners when a review
-   is due and tracks completion.
-
-7. **Exceptions must be explicit**  
-   Any broad-access exception for private repositories (for example, the cargo vet auditor team needing cross-repository
-   visibility, or security and release administration scenarios) must be explicitly documented and approved by the
-   Steering Committee or a formally delegated operations group. Each exception must record owner, scope, justification,
-   and review date.
-
-8. **Private means not discoverable within ODP unless authorized**  
-   For ODP governance purposes, a private repository should be treated as not visible to other ODP members unless they
-   are on the approved access list.
-
-9. **ODP platform and framework code must be contributed upstream**  
-   Any ODP platform or framework code developed within a private repository — including partner collaboration
-   repositories — must be contributed back upstream to a public ODP repository. Private repositories containing partner
-   intellectual property may remain private when justified, but they must not become the sole home for reusable ODP
-   platform or framework work. In all cases, private repositories must still comply with all other requirements in this
-   RFC (team-based access, 6-month audits, etc.).
+4. **No confidential content in the ODP organization**: The ODP organization must not host content that carries a
+   confidentiality obligation. This includes material covered by non-disclosure agreements or other non-public
+   information. Work that requires this kind of protection must be kept outside the ODP organization.
 
 ## Proposed Policy
 
 ODP adopts the following repository access policy:
 
-- **Public** repositories are intended for broad visibility and contribution.
-- **Private** repositories are intended to be visible only to explicitly authorized users. Partner collaboration
-  repositories containing partner IP may remain private when justified, but any ODP platform or framework code in those
-  repositories must be contributed back upstream to a public ODP repository.
+- **Public** repositories are intended for broad visibility and contribution, and represent the normal state for work in
+  the ODP organization.
+- **Private** repositories are a temporary staging state for content that is intended to become public and is being
+  prepared for release. While private, they are visible only to explicitly authorized users. Confidential content, and
+  repositories with no plan to become public, do not belong in the ODP organization.
+
 - ODP organization membership alone is insufficient to view or access a private repository.
 - ODP GitHub organization owners (admins) retain full visibility to all repositories as part of their platform
   administration role.
@@ -115,115 +107,17 @@ The following questions should be resolved during RFC review:
 
 1. Should there be a small number of standing exception teams (for example, security or release administration), and if
    so, how are those exceptions governed?
-   - Yes. Exceptions are addressed in Requirement 7 with explicit documentation and Steering Committee approval.
-2. What evidence should repository owners retain to show six-month access recertification was completed?
-   - Addressed in Requirement 6. Acceptable evidence includes a dated issue, pull request, or signed-off audit log, with
-     an automated reminder mechanism.
-3. Should direct collaborator grants on private repositories require additional justification or expiration?
-   - Direct grants now require documented justification (Requirement 2 and 4). Team-based access is required by default.
-4. Should ODP also define guidance for when work should move from private to public?
-   - Yes. Requirement 9 establishes that private repos should have a path to public, and a transition checklist is
-     provided in the Adoption Strategy.
+   - Yes. Exceptions are allowed with explicit documentation and Steering Committee approval.
+2. Should direct collaborator grants on private repositories require additional justification or expiration?
+   - Team-based access is required by default.
+3. Should ODP also define guidance for when work should move from private to public?
+   - Yes. The requirements establish that private repositories are only a temporary staging state and must have a plan
+     to become public, and a transition checklist is provided in the Adoption Strategy.
 
 ### Open
 
-1. Should private repositories containing partner IP have a maximum retention period (for example, 12 or 24 months),
-   after which the repository must be deleted or transferred out of the ODP organization?
-
-2. **Repeatable access audit record format**: Should each private repository be required to maintain a structured
-   `ACCESS-AUDIT.md` file committed directly to the repository as the canonical audit record? A proposed format would
-   include:
-   - A table of authorized teams and their permission levels, with grant date and justification.
-   - A table of any individual (direct collaborator) grants with justification and optional expiry date.
-   - An audit history table with one row per completed 6-month review, recording the review date, the auditor (GitHub
-     username), a summary of changes made, and a sign-off.
-
-   Example `ACCESS-AUDIT.md` structure:
-
-   ```markdown
-   # Access Audit Log
-
-   ## Authorized Access
-
-   ### Teams
-
-   | Team                             | Permission Level | Granted Date | Justification |
-   | -------------------------------- | ---------------- | ------------ | ------------- |
-   | @OpenDevicePartnership/team-name | Write            | YYYY-MM-DD   | Reason        |
-
-   ### Individual Grants (exceptions — require justification)
-
-   | GitHub Username | Permission Level | Granted Date | Justification | Expiry            |
-   | --------------- | ---------------- | ------------ | ------------- | ----------------- |
-   | @username       | Read             | YYYY-MM-DD   | Reason        | YYYY-MM-DD or N/A |
-
-   ## Audit History
-
-   | Review Date | Auditor   | Changes Made                      | Sign-off             |
-   | ----------- | --------- | --------------------------------- | -------------------- |
-   | YYYY-MM-DD  | @username | None / Removed @user, added @team | @username YYYY-MM-DD |
-   ```
-
-   An automated GitHub Actions workflow would run on a schedule every 6 months, check whether `ACCESS-AUDIT.md` has been
-   updated within the required period, and if overdue, open a GitHub issue in the repository and assign it to the
-   repository owner to prompt the audit review.
-
-   Example workflow:
-
-   ```yaml
-   name: Access Audit Reminder
-
-   on:
-     schedule:
-       - cron: "0 9 1 */6 *" # 9am UTC on the 1st of every 6th month
-     workflow_dispatch:
-
-   permissions:
-     issues: write
-     contents: read
-
-   jobs:
-     check-audit:
-       runs-on: ubuntu-latest
-       steps:
-         - uses: actions/checkout@v4
-
-         - name: Check ACCESS-AUDIT.md last updated date
-           id: check
-           run: |
-             if [ ! -f ACCESS-AUDIT.md ]; then
-               echo "missing=true" >> "$GITHUB_OUTPUT"
-             else
-               LAST=$(git log -1 --format="%ct" -- ACCESS-AUDIT.md)
-               NOW=$(date +%s)
-               DAYS=$(( (NOW - LAST) / 86400 ))
-               if [ "$DAYS" -gt 183 ]; then
-                 echo "overdue=true" >> "$GITHUB_OUTPUT"
-                 echo "days=$DAYS" >> "$GITHUB_OUTPUT"
-               fi
-             fi
-
-         - name: Get repo owner
-           id: owner
-           if: steps.check.outputs.overdue == 'true' || steps.check.outputs.missing == 'true'
-           run: |
-             OWNER=$(gh api repos/${{ github.repository }} --jq '.owner.login')
-             echo "login=$OWNER" >> "$GITHUB_OUTPUT"
-           env:
-             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-         - name: Create audit issue
-           if: steps.check.outputs.overdue == 'true' || steps.check.outputs.missing == 'true'
-           run: |
-             BODY="This repository's access audit is overdue.\n\nPer the ODP private repository access control policy, \`ACCESS-AUDIT.md\` must be reviewed and updated every 6 months.\n\nPlease:\n1. Review the current team and individual access grants.\n2. Remove any stale or unnecessary access.\n3. Add a new row to the Audit History table in \`ACCESS-AUDIT.md\` with today's date and your sign-off.\n4. Commit and push the updated file to close this issue."
-             gh issue create \
-               --title "Access audit required: ACCESS-AUDIT.md is overdue" \
-               --body "$(printf "$BODY")" \
-               --assignee "${{ steps.owner.outputs.login }}" \
-               --label "access-audit"
-           env:
-             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-   ```
+1. Should private repositories have a maximum time they may remain private (for example, 12 or 24 months) before they
+   must either become public or be removed from the ODP organization?
 
 ## Prior Art
 
@@ -237,24 +131,10 @@ for a clear policy about what "private" operationally means for maintainers and 
 
 ## Alternatives
 
-### Alternative 1: Make all ODP members able to see all private repositories (current behavior)
+### Alternative 1: Make all ODP members able to see all private repositories
 
-This is the current default in ODP. While it maximizes discoverability inside the organization, it weakens
-least-privilege controls and makes "private" less meaningful for sensitive or early-stage work. In practice, this is
-especially problematic for repositories that contain work related to unreleased hardware or that support early
-engagement with partners under confidentiality constraints. In those cases, broad visibility to all ODP members risks
-exposing pre-disclosure material to people who are not part of the relevant workstream, undermining the trust model that
-partners and hardware vendors expect.
-
-### Alternative 2: Create a separate GitHub organization for partner engagement
-
-A separate GitHub organization could be used to host private repositories intended for partner engagement and
-pre-release hardware work, keeping them fully isolated from the main ODP organization. However, maintaining a second
-GitHub organization is expensive in terms of licensing costs and introduces a significant maintenance burden. Teams,
-permissions, CI/CD integrations, and governance policies would need to be duplicated and kept in sync across both
-organizations. Contributors working across both organizations would face additional friction, and the split would
-fragment project history and tooling. The cost and operational complexity outweigh the benefits when the same isolation
-can be achieved through explicit access controls within a single organization.
+This could reduce administrative overhead, but it would also defeat the purpose of private repositories serving as a
+place to prepare content in a way that is meaningful to release to the intended audience.
 
 ## Rust Code Design
 
@@ -264,14 +144,16 @@ Not applicable.
 
 Contributors:
 
-- Use **public** when broad collaboration and discoverability are intended.
-- Use **private** when access should be intentionally restricted.
+- Use **public** for normal work, when broad collaboration and discoverability are intended.
+- Use **private** only to temporarily stage content that is intended to become public and is being prepared for release.
+- Do not place confidential content, including anything covered by a non-disclosure agreement, in the ODP organization.
 - Do not assume ODP membership implies private repository access.
 - Request private repository access through the appropriate team or explicit repository permission.
 
 Repository owners:
 
-- Choose private only when restricted visibility is intended.
+- Choose private only as a temporary staging state, with a plan to make the repository public.
+- Do not create a private repository that is intended to stay private indefinitely or that holds confidential material.
 - Maintain a deliberate access list.
 - Prefer team-based permissions over individual additions.
 - Periodically confirm that each person or team still needs access.
@@ -281,37 +163,27 @@ Repository owners:
 This policy applies to all private repositories upon RFC ratification. The rollout below defines remediation and
 verification steps:
 
-1. Configure organization settings immediately so membership alone does not grant private repository visibility.
+1. Configure organization settings immediately so membership is given by being a member of a GitHub team with access to
+   the private repository.
 2. Inventory existing private repositories in ODP.
-3. Review current access grants for those repositories.
-4. Remove broad or stale access that does not align with the new policy.
-5. Document any approved exception cases.
-6. Set up a scheduled GitHub Actions workflow (or equivalent automation) to remind repository owners of 6-month access
-   reviews and track audit completion.
+3. For each private repository, confirm it holds no confidential content and has a documented plan to become public.
+   Move confidential work out of the ODP organization, and either establish a path to public or remove any repository
+   that has no plan to become public.
+4. Review current access grants for those repositories.
+5. Remove broad or stale access that does not align with the new policy.
+6. Document any approved exception cases.
 
 ### Private-to-Public Transition Checklist
 
 When transitioning a repository from private to public, the repository owner must complete the following before changing
 visibility:
 
-1. Review the full git history for secrets, tokens, API keys, or credentials and remove them (consider using tools such
-   as `git filter-repo` or BFG Repo-Cleaner).
-2. Review the full git history for partner-sensitive, pre-disclosure, or personally identifiable information and remove
-   it.
+1. Review the full git history for secrets, tokens, API keys, or credentials and remove them.
+2. Review the full git history for sensitive or personally identifiable information and remove it.
 3. Ensure all dependencies are compatible with public distribution and licensing requirements.
 4. Confirm the repository license is correct and visible.
 5. Review and update the README and CODEOWNERS for public-facing context.
-6. Remove or redact any internal-only documentation, links, or references.
-7. Obtain sign-off from the repository owner or designated maintainer that the scrub is complete.
-
-Completion criteria:
-
-1. All private repositories have an explicit team-based or justified direct access model.
-2. Organization-wide membership does not grant private repository visibility by default.
-3. Approved exceptions are documented with owner, scope, justification, and review date.
-
-## Drawbacks
-
-This policy increases administrative overhead for repository owners and may slow down access for contributors who need
-to join a private workstream. It also reduces incidental discoverability of work inside ODP. Those tradeoffs are
-intentional and are the cost of a clearer least-privilege posture for private repositories.
+6. Remove or redact any non-public documentation, links, or references.
+7. Obtain sign-off from the repository owner and the ODP Steering Committee that the repository is ready to become
+   public.
+8. Remove GitHub teams and collaborators that are no longer needed for the public repository.


### PR DESCRIPTION
Status: FCP (started 8/6/2026 with plan to merge by 8/13/2026)

Updates the RFC to more generally cover private repository policy in
the OpenDevicePartnership GitHub organization.

Adds a requirement that private repositories are only for staging
content to go public and should not contain any confidential content
or material with no public plan. Simplifies requirements and overall
policy accordingly while still retaining GitHub teams to manage and
audit private repository access on a per-repository basis. Overall,
reduces administrative overhead for managing private repositories.