### PR TITLE
RFC: ODP Repository Naming Policy

### DIFF
--- a/rfc/text/0000-repository-naming-policy.md
+++ b/rfc/text/0000-repository-naming-policy.md
@@ -11,6 +11,8 @@ This text can be modified over time. Add a change log entry for every change mad
 - 2026-08-05: Initial RFC created.
 - 2026-08-12: Replaced reason-specific temporary repository labels with the generic `staging` label and moved
               submodule guidance to the requirements section.
+- 2026-08-12: Added preliminary study of which current repositories need to be renamed and clarified exemptions
+              in the requirements.
 
 ## Motivation
 
@@ -60,43 +62,24 @@ This RFC uses the following terms for naming cases:
 
 The naming policy has the following requirements:
 
+- This policy applies to public, active repositories hosted in the ODP GitHub organization. The following repositories
+  are exempt:
+  - Ancillary repositories whose names are established by GitHub or an organization-wide convention.
+  - Private repositories while they remain private.
+  - Archived repositories while they remain archived.
+  - Existing vendor repositories already staged for transfer out of ODP when this RFC is adopted.
 - Repository names use the pattern `<scope>[-<purpose>[-staging]]`.
-- Labels use lowercase ASCII letters and digits, with underscores between words.
-- Hyphens separate labels and do not appear within a label.
-- `<scope>` is required and indicates the ODP project or reserved organization-wide grouping associated with the
-  repository.
-  - Approved project scope labels are derived from the ODP project names maintained by the
-    [governing board](https://opendevicepartnership.org/projects) and normalized according to this policy. For example,
-    `Patina` and `Embedded Controller` become `patina` and `embedded_controller`.
-  - Reserved organization-wide scope labels are defined by this RFC and must not be introduced by individual
-    repositories.
-    - `common` is used for repositories associated with multiple projects or not clearly associated with a single
-      project.
-    - `governance` is used for the primary ODP governance repository and repositories that support organization-wide
-      governance through discussion or documentation.
-    - `platform` is used for repositories that integrate a bootable demonstration for a hardware or emulated target.
-  - The repository that represents the primary project may use the scope label by itself.
-  - Additional organization-wide scope labels require an update to this RFC.
-  - The scope label identifies the ODP project or organization-wide grouping associated with a repository and does
-    not assign repository ownership.
-- `<purpose>` is the tool, module, platform target, or other purpose that distinguishes the repository within its
-  scope. This label is required unless the repository represents the primary project or is an ancillary repository.
-  - The `<purpose>` label is omitted for the repository that represents the primary project.
-  - All other non-ancillary repositories include a `<purpose>` label.
-  - The label describes why the repository exists or what it is for, not its implementation language, packaging format,
-    or repository type.
-  - When a vendor name is needed, include it in the same `<purpose>` label as the item it identifies, separated with an
-    underscore; for example, `bq40z50_ti`.
-  - Project maintainers approve purpose labels within their scope.
-- The optional `staging` suffix follows `<purpose>` and indicates that a repository is hosted temporarily by ODP.
-  - A staging repository must be removed from ODP as soon as practical after its contents have been upstreamed,
-    transferred to an external owner, or are no longer needed.
-  - If ODP intends to maintain a repository, the repository must not include the `staging` suffix.
-  - An external vendor name used within the `<purpose>` label does not imply that the repository is staging.
+- Labels use lowercase ASCII letters and digits. Hyphens separate labels, and underscores separate words within a
+  label.
+- `<scope>` is required and identifies an approved ODP project or a reserved organization-wide grouping. Additional
+  reserved organization-wide scope labels require an update to this RFC.
+- `<purpose>` identifies what distinguishes a repository within its scope. It is required unless the repository
+  represents the primary project. Project maintainers approve purpose labels within their scope.
+- The `staging` suffix is required when ODP does not intend to host a repository long term and must not be used when ODP
+  intends to maintain the repository. A staging repository must be removed from ODP as soon as practical after its
+  contents have been upstreamed, transferred, or are no longer needed.
 - New ODP repositories must use this policy when they are created; existing repositories need a plan for adoption.
-- Ancillary repositories retain the names required by GitHub or an applicable organization-wide convention.
-- This policy applies only to the names of repositories hosted in the ODP GitHub organization. It does not govern the
-  name or path under which an ODP repository is included as a Git submodule in another repository.
+- This policy does not govern the name or path under which a repository is included as a Git submodule.
 
 ## Unresolved Questions
 
@@ -157,32 +140,144 @@ Not applicable.
 
 ## Guide-Level Explanation
 
-Choose labels from left to right:
+Choose labels for scope, purpose, and if staging is needed in the name `<scope>[-<purpose>[-staging]]`:
 
-1. Select the ODP project most directly associated with the repository as `<scope>` or a reserved organization-wide
-   label when applicable.
-2. Add `<purpose>` unless the repository represents the primary project. Choose terms that a contributor is likely to
-   search for, such as a capability, upstream repository, hardware target, or vendor and item name.
-3. Add the `staging` suffix when ODP does not intend to host the repository long term. Omit it for repositories that
-  ODP intends to maintain.
+- Scope: Select the ODP project most directly associated with the repository. Approved labels are derived from the
+  ODP project names maintained by the [governing board](https://opendevicepartnership.org/projects) and normalized
+  according to this policy. For example, `Patina` becomes `patina`.  Or use a reserved organization-wide scope when
+  no individual project is the appropriate scope:
+  - `common` for repositories associated with multiple projects or not clearly associated with one project.
+  - `governance` for the primary ODP governance repository and repositories supporting organization-wide governance or
+    rule enforcement.
+  - `platform` for repositories integrating a bootable demonstration for a hardware or emulated target.
+- Purpose: Select a label that represents the primary project within the scope. Describe why the repository exists,
+  rather than its language, packaging format, or repository type. When a vendor identifies an item, include both in
+  the same label, separated by an underscore; for example, `bq40z50_ti`.
+- Staging: Add the staging suffix when ODP does not intend to host and maintain the repository. A vendor name in
+  `<purpose>` does not by itself mean the repository is staging.
 
-The following examples illustrate how selected current repository names could follow this convention. They do not
-mandate the names to use going forward.
+As of 2026-08-12, a total of 89 repositories were visible to the author of this RFC under the ODP organization.  The
+following tables list suggested actions to take according to this specification for each one.  If other repositories
+are present in the org and are not listed due to access rights, they would fall under the 'private repo' listing table
+below.
 
-| Current Name | New Name | Notes |
+### Public Repositories that need changes
+
+The following 32 repositories out of the 89 were determined to be the ones that may need name changes.  There is
+another directive to reduce the number of repositories (example, 'embedded-drivers' repo with common build tools,
+documentation, layout, CI, etc.), which if done first could reduce this number to around 20.
+
+| Proposed Name | Current Name | Notes |
 | --- | --- | --- |
-| OpenDevicePartnership.github.io | OpenDevicePartnership.github.io | Unchanged ancillary repository |
-| governance | governance | Primary repository for the reserved `governance` scope |
-| documentation | governance-documentation | Organization-wide documentation supporting ODP governance |
-| cortex-m-stack | common-cortex_m_stack | ODP-owned Cortex-M support code not specific to one project |
-| odp-utilities | common-utilities | ODP-owned tools used by multiple projects |
-| pico-de-gallo | common-pico_de_gallo | Standalone ODP tool not associated with one project |
-| odp-platform-qemu-arm-virt | platform-qemu_arm_virt | Arm-specific emulation platform that boots to a Windows desktop |
-| odp-platform-radxa-orion-o6 | platform-radxa_orion_o6 | Platform demonstration that boots a Radxa Orion O6 to a Windows desktop |
-| edk2 | platform-edk2-staging | Temporary EDK II fork for platform builds; changes are intended for upstreaming |
-| odp-embedded-controller | embedded_controller | Primary Embedded Controller project repository |
-| is31fl3743b | embedded_controller-is31fl3743b_lumissil-staging | ODP-authored driver intended for handoff to Lumissil |
-| bq40z50 | embedded_controller-bq40z50_ti-staging | ODP-authored driver intended for handoff to TI |
-| zephyr | embedded_controller-zephyr-staging | Temporary Zephyr fork for EC repositories; changes are intended for upstreaming |
-| patina-apps | patina-apps | Applications specific to the Patina project |
-| patina-qemu | patina-qemu | QEMU emulation repository specific to the Patina project |
+| **common** | | |
+| common-cga | cga | Call graph analysis tool |
+| common-crateplace | crateplace | Embedded crate placement tool |
+| common-pico_de_gallo | pico-de-gallo | QEMU build tooling |
+| common-qemu_builder | odp-qemu-builder | QEMU build tooling |
+| **embedded** | | |
+| embedded | odp-embedded-controller | Primary Embedded Controller project repository |
+| embedded-keyboard_rs | embedded-keyboard-rs | Matrix keyboard driver |
+| embedded-power_sequence | embedded-power-sequence | SoC power sequencing HAL |
+| embedded-usb_pd | embedded-usb-pd | USB Power Delivery types |
+| embedded-utilities | odp-utilities | Tools used across ODP EC projects |
+| embedded-cortex_m_stack | cortex-m-stack | ODP-owned Cortex-M stack usage tools |
+| embedded-systemview_tracing | systemview-tracing | Tracing support |
+| embedded-slimloader | ec-slimloader | Embedded Controller stage-one bootloader |
+| embedded-zephyr_lang_rust-staging | zephyr-lang-rust | Temporary Zephyr fork |
+| embedded-zephyr-staging | zephyr | Temporary Zephyr fork |
+| **governance** | | |
+| governance-discussions | discussions | Organization-wide community discussions |
+| governance-documentation | documentation | Organization-wide documentation supporting ODP governance |
+| governance-rust_driver_template | drive-rs | Rust driver project template; confirm organization-wide scope |
+| governance-rust_crate_audits | rust-crate-audits | Organization-wide Rust crate audits |
+| **patina** | | |
+| patina-dxe_core_qemu | patina-dxe-core-qemu | Patina DXE Core build for QEMU |
+| patina-fw_patcher | patina-fw-patcher | Patina firmware patching tool |
+| patina-readiness_tool | patina-readiness-tool | Patina platform readiness tools |
+| **platform** | | |
+| platform-common | odp-platform-common | Common platform integration content |
+| platform-qemu | odp-platform-qemu-arm-virt | Arm virtual platform demonstration |
+| platform-radxa_orion_o6 | odp-platform-radxa-orion-o6 | Radxa Orion O6 platform demonstration |
+| platform-windows_drivers | odp-windows-drivers | Windows drivers |
+| platform-arm_trusted_firmware-staging | arm-trusted-firmware | Trusted Firmware-A mirror |
+| platform-edk2-staging | edk2 | Temporary EDK II fork for platform builds |
+| platform-ffa-staging | ffa | Arm Firmware Framework library |
+| **secure services** | | |
+| services | embedded-services | Primary Secure Services framework and service implementations |
+| services-hafnium | odp-secure-services | Hafnium deployment of secure services |
+| services-hafnium_platforms-staging | odp-hafnium-project | Imported Hafnium platform configurations with ODP-specific changes |
+| N/A (unused) | hafnium | Mirror repo with no ODP activity, assuming it will be deleted |
+
+### Public Repositories Named Properly
+
+Under this RFC, several of the repositories are already named properly.  This assumes the name used to represent each of the projects under
+the ODP umbrella are patina, embedded, and services.  This list removes another 16 of the 89 repositories from the list of names that need
+to change.
+
+| Repository Name | Notes |
+| --- | --- |
+| embedded-batteries | Battery fuel gauge and charger HAL |
+| embedded-cfu | Component Firmware Update library |
+| embedded-fans | Fan control HAL |
+| embedded-mcu | MCU-agnostic traits and libraries |
+| embedded-perfmon | Confirm purpose and long-term ownership |
+| embedded-regulator | Voltage regulator HAL |
+| embedded-sensors | Sensor HAL |
+| governance | Primary repository for the reserved `governance` scope |
+| patina | Primary Patina project repository |
+| patina-apps | Patina applications |
+| patina-components | Components used with Patina |
+| patina-devops | Patina development operations |
+| patina-edk2 | Patina definitions for EDK II-style C code |
+| patina-mtrr | Patina Memory Type Range Register support |
+| patina-paging | Patina paging support |
+| patina-qemu | Patina QEMU demonstration |
+
+### Exempt Repositories
+
+Under this RFC, any ancillary, private, currently staged vendor, and archived repos are exempt from the naming convention.
+Those rules allow 41 of the 89 repositories to be removed from the naming change.
+
+| Repository Name | Policy |
+| --- | --- |
+| .github | Ancillary repository |
+| basic-template | Private repository |
+| bq25763 | Private repository |
+| ec-slimloader-descriptors | Archived public repository |
+| ec-test-app | Archived public repository |
+| embassy-imxrt | Current vendor staging repository |
+| embassy-mcxa | Current vendor staging repository |
+| embassy-npcx | Current vendor staging repository |
+| embedded-rust-template | Private repository |
+| gh-orchestrator | Private repository |
+| mcxa-pac | Current vendor staging repository |
+| mec17xx-pac | Current vendor staging repository |
+| mctp-rs | Archived public repository |
+| mimxrt600-fcb | Current vendor staging repository |
+| mimxrt633s-pac | Current vendor staging repository |
+| mimxrt685s-pac | Current vendor staging repository |
+| mimxrt685s-examples | Archived public repository |
+| modern-payload | Private repository |
+| npcx490m-pac | Current vendor staging repository |
+| npcx490m-examples | Archived public repository |
+| odp-platform-qemu-q35 | Private repository |
+| OpenDevicePartnership.github.io | Ancillary repository |
+| patina-lzma-rs | Private repository |
+| pfd-devops | Private repository |
+| slimloader | Private repository |
+| soc-embedded-controller | Private repository |
+| standup-dashboard | Private repository |
+| uefi-bds | Private repository |
+| uefi-corosensei | Archived public repository |
+| uefi-sdk | Private repository |
+| INA4230 | Texas Instruments staging repository |
+| bq25723 | Texas Instruments staging repository |
+| bq25770g | Texas Instruments staging repository |
+| bq25773 | Texas Instruments staging repository |
+| bq40z50 | Texas Instruments staging repository |
+| bq41z50 | Texas Instruments staging repository |
+| is31fl3743b | Lumissil Microsystems staging repository |
+| lis2dw12-i2c | STMicroelectronics staging repository |
+| pcal6416a | NXP Semiconductors staging repository |
+| tmp108 | Texas Instruments staging repository |
+| tps6699x | Texas Instruments staging repository |

--- a/rfc/text/0000-repository-naming-policy.md
+++ b/rfc/text/0000-repository-naming-policy.md
@@ -1,0 +1,198 @@
+# RFC: ODP Repository Naming Policy
+
+This RFC defines the naming policy for repositories in the Open Device Partnership (ODP) GitHub organization. The
+policy communicates each repository's scope and purpose. For repositories temporarily hosted by ODP, it also
+communicates whether the repository is a fork or is intended for handoff.
+
+## Change Log
+
+This text can be modified over time. Add a change log entry for every change made to the RFC.
+
+- 2026-08-05: Initial RFC created.
+
+## Motivation
+
+ODP repositories have been created at different times by different projects without a shared naming convention.
+Current names use inconsistent prefixes, separators, abbreviations, and ordering. Some identify an ODP project, some
+identify a technology, target, or vendor, and others do not communicate how the repository relates to ODP or an
+upstream project.
+
+This inconsistency makes repository names difficult to interpret without opening each repository. It also makes it
+harder for contributors to browse or search the organization by project, distinguish project repositories from
+organization-wide repositories, and identify temporary forks or work intended for transfer to an external owner.
+
+A shared convention gives each label in a repository name one meaning and a predictable position. It allows every name
+to answer the following questions:
+
+1. Which ODP project or organization-wide grouping is this repository associated with?
+2. What distinguishes this repository within that scope?
+3. Is this repository a temporary fork or handoff pending removal from ODP?
+
+## Technology Background
+
+ODP hosts repositories for individual projects, organization-wide functions, platform demonstrations, and temporary
+collaboration with external projects or vendors. GitHub presents these repositories together at the organization
+level, where the repository name is the primary information available before a contributor opens it. A predictable
+name therefore helps contributors identify relevant repositories while browsing, searching, or following links from
+outside ODP.
+
+Git repository names do not define code architecture, package names, or ownership. An ODP repository may contain one
+or more modules, tools, applications, or build targets without those choices changing the naming convention.
+
+An external repository referenced as a Git submodule is not an ODP repository. Its canonical name and the path
+recorded in `.gitmodules` remain under the control of the consuming repository and are outside this convention. This
+distinguishes unchanged external dependencies from external code temporarily hosted in an ODP repository.
+
+This RFC uses the following terms for naming cases:
+
+- **Ancillary repository** - A repository whose exact name is established by GitHub or an organization-wide
+  convention, such as `OpenDevicePartnership.github.io`.
+- **Temporary fork** - An ODP-hosted repository whose canonical source originated outside ODP and which is retained
+  only while ODP changes are being upstreamed to that source.
+- **Handoff repository** - An ODP-authored repository hosted temporarily by ODP and intended to be transferred to an
+  identified external owner.
+
+## Goals
+
+1. Make ODP repository names consistent and interpretable across the organization.
+2. Identify the ODP project or organization-wide grouping associated with each repository.
+3. Make a repository's distinguishing purpose discoverable from its name when the scope alone is insufficient.
+4. Identify temporary forks and handoff repositories so contributors do not mistake them for repositories ODP intends
+   to maintain.
+5. Support contributors searching by project, capability, upstream repository, hardware target, or vendor and item
+   name.
+
+## Requirements
+
+The naming policy has the following requirements:
+
+- Repository names use the pattern `<scope>[-<purpose>[-<temporary_status>]]`.
+- Labels use lowercase ASCII letters and digits, with underscores between words.
+- Hyphens separate labels and do not appear within a label.
+- `<scope>` is required and indicates the ODP project or reserved organization-wide grouping associated with the
+  repository.
+  - Approved project scope labels are derived from the ODP project names maintained by the
+    [governing board](https://opendevicepartnership.org/projects) and normalized according to this policy. For example,
+    `Patina` and `Embedded Controller` become `patina` and `embedded_controller`.
+  - Reserved organization-wide scope labels are defined by this RFC and must not be introduced by individual
+    repositories.
+  - The repository that represents the primary project may use the scope label by itself.
+  - This RFC reserves `common` for repositories associated with multiple projects or not clearly associated with
+    a single project.
+  - This RFC reserves `governance` for the primary ODP governance repository and repositories that support
+    organization-wide governance through discussion or documentation.
+  - This RFC reserves `platform` for repositories that integrate a bootable demonstration for a hardware or emulated
+    target.
+  - Additional organization-wide scope labels require an update to this RFC.
+  - The scope label identifies the ODP project or organization-wide grouping associated with a repository and does
+    not assign repository ownership.
+- `<purpose>` is the tool, module, platform target, or other purpose that distinguishes the repository within its
+  scope. This label is required unless the repository represents the primary project or is an ancillary repository.
+  - The `<purpose>` label is omitted for the repository that represents the primary project.
+  - All other non-ancillary repositories include a `<purpose>` label.
+  - The label describes why the repository exists or what it is for, not its implementation language, packaging format,
+    or repository type.
+  - When a vendor name is needed, include it in the same `<purpose>` label as the item it identifies, separated with an
+    underscore; for example, `bq40z50_ti`.
+  - Project maintainers approve purpose labels within their scope.
+- `<temporary_status>` is optional, follows `<purpose>`, and may only be `fork` or `handoff`, indicating why a
+  repository is hosted temporarily by ODP.
+  - The `<temporary_status>` label uses `fork` for a temporary fork and `handoff` for a repository intended for handoff
+    to an external owner.
+  - A repository with this label is classified as temporary and must be removed from ODP as soon as practical after its
+    changes or contents have moved out of the organization.
+  - For a temporary fork, the `<purpose>` label uses the canonical upstream repository name targeted for the ODP changes,
+    converted to a valid label according to this policy.
+  - For a handoff repository, the `<purpose>` label identifies the item and should include its intended owner.
+  - If ODP intends to maintain a repository, the repository must not include a `<temporary_status>` label.
+  - An external vendor name used within the `<purpose>` label does not imply a temporary status.
+- New ODP repositories must use this policy when they are created; existing repositories need a plan for adoption.
+- Ancillary repositories retain the names required by GitHub or an applicable organization-wide convention.
+
+## Unresolved Questions
+
+No unresolved questions are currently known for the naming grammar itself. Review of this RFC may identify additional
+reserved organization-wide scopes or naming cases that the proposed labels do not represent. The following related
+decisions are outside the scope of this RFC:
+
+- The final list of repositories to rename and their approved new names.
+- Whether existing repositories should be combined, divided, transferred, archived, or removed.
+- The schedule, tooling, and ownership for repository renames.
+- Enforcement mechanisms and deadlines for adopting the policy.
+- Repository contents, layout, documentation, build, CI, release, and ownership policy.
+
+## Prior Art
+
+Existing ODP repository names demonstrate several naming approaches. Some use an `odp-` prefix, such as
+`odp-platform-qemu-arm-virt`; some use a project prefix, such as `patina-apps`; and others use an unscoped capability,
+device, or upstream project name, such as `cortex-m-stack`, `bq40z50`, or `edk2`. These names are the direct prior art
+for this proposal, but no single existing approach consistently identifies scope, purpose, and temporary status.
+
+The proposed convention retains useful project and purpose terms from existing names while assigning them predictable
+positions. The examples in the Guide-Level Explanation section show how representative existing names map to the
+proposed convention.
+
+## Alternatives
+
+### Keep Existing Names
+
+ODP could leave repository naming to individual projects. This avoids migration work but preserves the current
+inconsistency and requires contributors to open repositories to determine their relationship to ODP.
+
+### Use Only Scope and Purpose
+
+The convention could omit `<temporary_status>` and use only `<scope>-<purpose>`. This is simpler, but temporary forks
+and handoff repositories would be indistinguishable from repositories ODP intends to maintain.
+
+### Use Vendor Names as Scope
+
+Repositories associated with a hardware vendor could use that vendor as `<scope>`. This would make vendor searches
+direct, but it would obscure the ODP project responsible for the work and could incorrectly imply vendor ownership.
+Vendor and item names therefore belong in `<purpose>` when they help distinguish a repository.
+
+### Encode the Source or Owner in Temporary Status
+
+The temporary label could include the upstream source or intended owner, such as `edk2_fork` or `ti_handoff`. This
+duplicates information already carried by `<purpose>` and makes the third label describe both identity and status.
+Using the literal flags `fork` and `handoff` gives `<temporary_status>` one meaning.
+
+### Use Hyphens for All Word Boundaries
+
+Repository names could use hyphens both between labels and between words within labels. This is familiar, but it makes
+the label boundaries ambiguous. Using hyphens between labels and underscores within labels keeps the name parseable.
+
+## Rust Code Design
+
+Not applicable.
+
+## Guide-Level Explanation
+
+Choose labels from left to right:
+
+1. Select the ODP project most directly associated with the repository as `<scope>` or a reserved organization-wide
+   label when applicable.
+2. Add `<purpose>` unless the repository represents the primary project. Choose terms that a contributor is likely to
+   search for, such as a capability, upstream repository, hardware target, or vendor and item name.
+3. Add `<temporary_status>` only when the repository is a temporary fork or handoff. Omit it for repositories that ODP
+   intends to maintain.
+
+The following examples illustrate how selected current repository names could follow this convention. They do not
+mandate the names to use going forward.
+
+| Current Name | New Name | Notes |
+| --- | --- | --- |
+| OpenDevicePartnership.github.io | OpenDevicePartnership.github.io | Unchanged ancillary repository |
+| governance | governance | Primary repository for the reserved `governance` scope |
+| documentation | governance-documentation | Organization-wide documentation supporting ODP governance |
+| cortex-m-stack | common-cortex_m_stack | ODP-owned Cortex-M support code not specific to one project |
+| odp-utilities | common-utilities | ODP-owned tools used by multiple projects |
+| pico-de-gallo | common-pico_de_gallo | Standalone ODP tool not associated with one project |
+| odp-platform-qemu-arm-virt | platform-qemu_arm_virt | Arm-specific emulation platform that boots to a Windows desktop |
+| odp-platform-radxa-orion-o6 | platform-radxa_orion_o6 | Platform demonstration that boots a Radxa Orion O6 to a Windows desktop |
+| edk2 | platform-edk2-fork | Temporary EDK II fork for platform builds; changes are intended for upstreaming |
+| odp-embedded-controller | embedded_controller | Primary Embedded Controller project repository |
+| is31fl3743b | embedded_controller-is31fl3743b_lumissil-handoff | ODP-authored driver intended for handoff to Lumissil |
+| bq40z50 | embedded_controller-bq40z50_ti-handoff | ODP-authored driver intended for handoff to TI |
+| zephyr | embedded_controller-zephyr-fork | Temporary Zephyr fork for EC repositories; changes are intended for upstreaming |
+| patina-apps | patina-apps | Applications specific to the Patina project |
+| patina-qemu | patina-qemu | QEMU emulation repository specific to the Patina project |

--- a/rfc/text/0000-repository-naming-policy.md
+++ b/rfc/text/0000-repository-naming-policy.md
@@ -2,13 +2,15 @@
 
 This RFC defines the naming policy for repositories in the Open Device Partnership (ODP) GitHub organization. The
 policy communicates each repository's scope and purpose. For repositories temporarily hosted by ODP, it also
-communicates whether the repository is a fork or is intended for handoff.
+communicates that the repository is not intended to remain in the organization long term.
 
 ## Change Log
 
 This text can be modified over time. Add a change log entry for every change made to the RFC.
 
 - 2026-08-05: Initial RFC created.
+- 2026-08-12: Replaced reason-specific temporary repository labels with the generic `staging` label and moved
+              submodule guidance to the requirements section.
 
 ## Motivation
 
@@ -19,14 +21,14 @@ upstream project.
 
 This inconsistency makes repository names difficult to interpret without opening each repository. It also makes it
 harder for contributors to browse or search the organization by project, distinguish project repositories from
-organization-wide repositories, and identify temporary forks or work intended for transfer to an external owner.
+organization-wide repositories, and identify repositories that ODP does not intend to host long term.
 
 A shared convention gives each label in a repository name one meaning and a predictable position. It allows every name
 to answer the following questions:
 
 1. Which ODP project or organization-wide grouping is this repository associated with?
 2. What distinguishes this repository within that scope?
-3. Is this repository a temporary fork or handoff pending removal from ODP?
+3. Is this repository staged temporarily in the ODP organization?
 
 ## Technology Background
 
@@ -39,26 +41,18 @@ outside ODP.
 Git repository names do not define code architecture, package names, or ownership. An ODP repository may contain one
 or more modules, tools, applications, or build targets without those choices changing the naming convention.
 
-An external repository referenced as a Git submodule is not an ODP repository. Its canonical name and the path
-recorded in `.gitmodules` remain under the control of the consuming repository and are outside this convention. This
-distinguishes unchanged external dependencies from external code temporarily hosted in an ODP repository.
-
 This RFC uses the following terms for naming cases:
 
 - **Ancillary repository** - A repository whose exact name is established by GitHub or an organization-wide
   convention, such as `OpenDevicePartnership.github.io`.
-- **Temporary fork** - An ODP-hosted repository whose canonical source originated outside ODP and which is retained
-  only while ODP changes are being upstreamed to that source.
-- **Handoff repository** - An ODP-authored repository hosted temporarily by ODP and intended to be transferred to an
-  identified external owner.
+- **Staging repository** - An ODP-hosted repository that is not intended to remain in the ODP organization long term.
 
 ## Goals
 
 1. Make ODP repository names consistent and interpretable across the organization.
 2. Identify the ODP project or organization-wide grouping associated with each repository.
 3. Make a repository's distinguishing purpose discoverable from its name when the scope alone is insufficient.
-4. Identify temporary forks and handoff repositories so contributors do not mistake them for repositories ODP intends
-   to maintain.
+4. Identify staging repositories so contributors do not mistake them for repositories ODP intends to maintain.
 5. Support contributors searching by project, capability, upstream repository, hardware target, or vendor and item
    name.
 
@@ -66,7 +60,7 @@ This RFC uses the following terms for naming cases:
 
 The naming policy has the following requirements:
 
-- Repository names use the pattern `<scope>[-<purpose>[-<temporary_status>]]`.
+- Repository names use the pattern `<scope>[-<purpose>[-staging]]`.
 - Labels use lowercase ASCII letters and digits, with underscores between words.
 - Hyphens separate labels and do not appear within a label.
 - `<scope>` is required and indicates the ODP project or reserved organization-wide grouping associated with the
@@ -94,17 +88,15 @@ The naming policy has the following requirements:
   - When a vendor name is needed, include it in the same `<purpose>` label as the item it identifies, separated with an
     underscore; for example, `bq40z50_ti`.
   - Project maintainers approve purpose labels within their scope.
-- `<temporary_status>` follows `<purpose>`, and indicates why a repository is hosted temporarily by ODP.
-  - The label uses the following pre-defined names:
-    - `fork` represents a fork of an external repository that contains ODP changes, is classified as temporary, and
-      must be removed from ODP as soon as practical after its changes or contents have been upstreamed. A fork will
-      also require the `<purpose>` label to the upstream repository's name.
-    - `handoff` represents a reposory created by ODP, but is intended to be moved to an external organization's
-      repository as soon as practical and removed from ODP.
-  - If ODP intends to maintain a repository, the repository must not include a `<temporary_status>` label.
-  - An external vendor name used within the `<purpose>` label does not imply a temporary status.
+- The optional `staging` suffix follows `<purpose>` and indicates that a repository is hosted temporarily by ODP.
+  - A staging repository must be removed from ODP as soon as practical after its contents have been upstreamed,
+    transferred to an external owner, or are no longer needed.
+  - If ODP intends to maintain a repository, the repository must not include the `staging` suffix.
+  - An external vendor name used within the `<purpose>` label does not imply that the repository is staging.
 - New ODP repositories must use this policy when they are created; existing repositories need a plan for adoption.
 - Ancillary repositories retain the names required by GitHub or an applicable organization-wide convention.
+- This policy applies only to the names of repositories hosted in the ODP GitHub organization. It does not govern the
+  name or path under which an ODP repository is included as a Git submodule in another repository.
 
 ## Unresolved Questions
 
@@ -138,8 +130,8 @@ inconsistency and requires contributors to open repositories to determine their 
 
 ### Use Only Scope and Purpose
 
-The convention could omit `<temporary_status>` and use only `<scope>-<purpose>`. This is simpler, but temporary forks
-and handoff repositories would be indistinguishable from repositories ODP intends to maintain.
+The convention could omit the `staging` suffix and use only `<scope>-<purpose>`. This is simpler, but staging
+repositories would be indistinguishable from repositories ODP intends to maintain.
 
 ### Use Vendor Names as Scope
 
@@ -147,11 +139,12 @@ Repositories associated with a hardware vendor could use that vendor as `<scope>
 direct, but it would obscure the ODP project responsible for the work and could incorrectly imply vendor ownership.
 Vendor and item names therefore belong in `<purpose>` when they help distinguish a repository.
 
-### Encode the Source or Owner in Temporary Status
+### Use Reason-Specific Temporary Status Labels
 
-The temporary label could include the upstream source or intended owner, such as `edk2_fork` or `ti_handoff`. This
-duplicates information already carried by `<purpose>` and makes the third label describe both identity and status.
-Using the literal flags `fork` and `handoff` gives `<temporary_status>` one meaning.
+The temporary status could identify why a repository is hosted temporarily, using labels such as `fork` or `handoff`.
+This would provide more detail in the name, but it would restrict the known reasons for temporary hosting and require
+new labels as other cases arise. The literal `staging` suffix identifies temporary repositories without constraining
+why they are temporary.
 
 ### Use Hyphens for All Word Boundaries
 
@@ -170,8 +163,8 @@ Choose labels from left to right:
    label when applicable.
 2. Add `<purpose>` unless the repository represents the primary project. Choose terms that a contributor is likely to
    search for, such as a capability, upstream repository, hardware target, or vendor and item name.
-3. Add `<temporary_status>` only when the repository is a temporary fork or handoff. Omit it for repositories that ODP
-   intends to maintain.
+3. Add the `staging` suffix when ODP does not intend to host the repository long term. Omit it for repositories that
+  ODP intends to maintain.
 
 The following examples illustrate how selected current repository names could follow this convention. They do not
 mandate the names to use going forward.
@@ -186,10 +179,10 @@ mandate the names to use going forward.
 | pico-de-gallo | common-pico_de_gallo | Standalone ODP tool not associated with one project |
 | odp-platform-qemu-arm-virt | platform-qemu_arm_virt | Arm-specific emulation platform that boots to a Windows desktop |
 | odp-platform-radxa-orion-o6 | platform-radxa_orion_o6 | Platform demonstration that boots a Radxa Orion O6 to a Windows desktop |
-| edk2 | platform-edk2-fork | Temporary EDK II fork for platform builds; changes are intended for upstreaming |
+| edk2 | platform-edk2-staging | Temporary EDK II fork for platform builds; changes are intended for upstreaming |
 | odp-embedded-controller | embedded_controller | Primary Embedded Controller project repository |
-| is31fl3743b | embedded_controller-is31fl3743b_lumissil-handoff | ODP-authored driver intended for handoff to Lumissil |
-| bq40z50 | embedded_controller-bq40z50_ti-handoff | ODP-authored driver intended for handoff to TI |
-| zephyr | embedded_controller-zephyr-fork | Temporary Zephyr fork for EC repositories; changes are intended for upstreaming |
+| is31fl3743b | embedded_controller-is31fl3743b_lumissil-staging | ODP-authored driver intended for handoff to Lumissil |
+| bq40z50 | embedded_controller-bq40z50_ti-staging | ODP-authored driver intended for handoff to TI |
+| zephyr | embedded_controller-zephyr-staging | Temporary Zephyr fork for EC repositories; changes are intended for upstreaming |
 | patina-apps | patina-apps | Applications specific to the Patina project |
 | patina-qemu | patina-qemu | QEMU emulation repository specific to the Patina project |

--- a/rfc/text/0000-repository-naming-policy.md
+++ b/rfc/text/0000-repository-naming-policy.md
@@ -76,13 +76,12 @@ The naming policy has the following requirements:
     `Patina` and `Embedded Controller` become `patina` and `embedded_controller`.
   - Reserved organization-wide scope labels are defined by this RFC and must not be introduced by individual
     repositories.
+    - `common` is used for repositories associated with multiple projects or not clearly associated with a single
+      project.
+    - `governance` is used for the primary ODP governance repository and repositories that support organization-wide
+      governance through discussion or documentation.
+    - `platform` is used for repositories that integrate a bootable demonstration for a hardware or emulated target.
   - The repository that represents the primary project may use the scope label by itself.
-  - This RFC reserves `common` for repositories associated with multiple projects or not clearly associated with
-    a single project.
-  - This RFC reserves `governance` for the primary ODP governance repository and repositories that support
-    organization-wide governance through discussion or documentation.
-  - This RFC reserves `platform` for repositories that integrate a bootable demonstration for a hardware or emulated
-    target.
   - Additional organization-wide scope labels require an update to this RFC.
   - The scope label identifies the ODP project or organization-wide grouping associated with a repository and does
     not assign repository ownership.
@@ -95,15 +94,13 @@ The naming policy has the following requirements:
   - When a vendor name is needed, include it in the same `<purpose>` label as the item it identifies, separated with an
     underscore; for example, `bq40z50_ti`.
   - Project maintainers approve purpose labels within their scope.
-- `<temporary_status>` is optional, follows `<purpose>`, and may only be `fork` or `handoff`, indicating why a
-  repository is hosted temporarily by ODP.
-  - The `<temporary_status>` label uses `fork` for a temporary fork and `handoff` for a repository intended for handoff
-    to an external owner.
-  - A repository with this label is classified as temporary and must be removed from ODP as soon as practical after its
-    changes or contents have moved out of the organization.
-  - For a temporary fork, the `<purpose>` label uses the canonical upstream repository name targeted for the ODP changes,
-    converted to a valid label according to this policy.
-  - For a handoff repository, the `<purpose>` label identifies the item and should include its intended owner.
+- `<temporary_status>` follows `<purpose>`, and indicates why a repository is hosted temporarily by ODP.
+  - The label uses the following pre-defined names:
+    - `fork` represents a fork of an external repository that contains ODP changes, is classified as temporary, and
+      must be removed from ODP as soon as practical after its changes or contents have been upstreamed. A fork will
+      also require the `<purpose>` label to the upstream repository's name.
+    - `handoff` represents a reposory created by ODP, but is intended to be moved to an external organization's
+      repository as soon as practical and removed from ODP.
   - If ODP intends to maintain a repository, the repository must not include a `<temporary_status>` label.
   - An external vendor name used within the `<purpose>` label does not imply a temporary status.
 - New ODP repositories must use this policy when they are created; existing repositories need a plan for adoption.


### PR DESCRIPTION
# RFC: ODP Repository Naming Policy

This RFC defines the naming policy for repositories in the Open Device Partnership (ODP) GitHub organization. The
policy communicates each repository's scope and purpose. For repositories temporarily hosted by ODP, it also
communicates whether the repository is a fork or is intended for handoff.